### PR TITLE
Feature: apt proxy handling

### DIFF
--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -310,3 +310,6 @@ system_email_recipient:
 # `enableMOTD` to the value `false` or uncomment the line afterwards ( default
 # value is `true`).
 # enableMOTD: false
+
+# To enable proxy usage for APT, please uncomment the line below.
+# ENABLE_PROXY_FOR_APT: "true"

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: Configure proxy for apt
   when: 
   - http_proxy is defined
-  - USE_APNS_STANDARD_PORT == true
+  - ENABLE_PROXY_FOR_APT == true
   template: src=apt.proxy.conf.j2 dest=/etc/apt/apt.conf.d/01proxy
 
 - name: Remove apt proxy configuration when no proxy is configured
-  when: USE_APNS_STANDARD_PORT == false or http_proxy is not defined
+  when: ENABLE_PROXY_FOR_APT == false or http_proxy is not defined
   file: dest=/etc/apt/apt.conf.d/01proxy state=absent
 
 # Installing dnsmasq is a chicken/egg problem: the apt cache must be updated

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Configure proxy for apt
-  when: http_proxy is defined
+  when: 
+  - http_proxy is defined
+  - USE_APNS_STANDARD_PORT == true
   template: src=apt.proxy.conf.j2 dest=/etc/apt/apt.conf.d/01proxy
 
 - name: Remove apt proxy configuration when no proxy is configured

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -6,7 +6,7 @@
   template: src=apt.proxy.conf.j2 dest=/etc/apt/apt.conf.d/01proxy
 
 - name: Remove apt proxy configuration when no proxy is configured
-  when: http_proxy is not defined
+  when: USE_APNS_STANDARD_PORT == false or http_proxy is not defined
   file: dest=/etc/apt/apt.conf.d/01proxy state=absent
 
 # Installing dnsmasq is a chicken/egg problem: the apt cache must be updated


### PR DESCRIPTION
Hello,

we have a use case that "http_proxy" should not be used for "apt" because we run our own mirror servers.
As a result, we need to manually correct the proxy configuration of "apt" through the platform ansible tools after each run.

I would be happy if this pull request is accepted.